### PR TITLE
fix(#2182): regex validations against swagger interface spec no longer working

### DIFF
--- a/collections/hub/golden_path/quoting_service/quoting_service.json
+++ b/collections/hub/golden_path/quoting_service/quoting_service.json
@@ -483,7 +483,7 @@
                 "id": 3,
                 "description": "Check Missing mandatory element - Invalid accept header",
                 "exec": [
-                  "expect(response.body.errorInformation.errorDescription).to.include('should have required property \\'accept\\'');"
+                  "expect(response.body.errorInformation.errorDescription).to.include('/header must have required property \\'accept\\'');"
                 ]
               }
             ]


### PR DESCRIPTION
fix(#2182): regex validations against swagger interface spec no longer working 
- See breaking changes for https://github.com/ajv-validator/ajv/releases/tag/v8.0.0