### PR TITLE
fix(mojaloop/#3024): [core bulk] POST /bulkTransfers from Switch to PayeeFSP to use Switch as fspiop-source

### DIFF
--- a/collections/hub/other_tests/bulk_transfers/bulk-duplicated-transfers.json
+++ b/collections/hub/other_tests/bulk_transfers/bulk-duplicated-transfers.json
@@ -8,7 +8,7 @@
         "info": "negative scenario - duplicate repeat bulk transfer"
       },
       "fileInfo": {
-        "path": "bulk_transfers/bulk-duplicated-transfers.json"
+        "path": "hub/other_tests/bulk_transfers/bulk-duplicated-transfers.json"
       },
       "requests": [
         {
@@ -90,9 +90,9 @@
               },
               {
                 "id": 3,
-                "description": "payerfsp callback - fspiop-source should be payeefsp",
+                "description": "payerfsp callback - fspiop-source should be switch",
                 "exec": [
-                  "expect(callback.headers['fspiop-source']).to.equal(environment.toFspId)"
+                  "expect(callback.headers['fspiop-source']).to.equal('switch')"
                 ]
               },
               {
@@ -234,9 +234,9 @@
               },
               {
                 "id": 23,
-                "description": "payeefsp request - fspiop-source should be testingtoolkitdfsp",
+                "description": "payeefsp request - fspiop-source should be switch",
                 "exec": [
-                  "expect(environment.bulkTransfersNegativeRequest.headers['fspiop-source']).to.equal(environment.fromFspId)"
+                  "expect(environment.bulkTransfersNegativeRequest.headers['fspiop-source']).to.equal('switch')"
                 ]
               },
               {
@@ -552,7 +552,7 @@
         "info": "negative scenario - duplicate modified bulk transfer"
       },
       "fileInfo": {
-        "path": "bulk_transfers/bulk-duplicated-transfers.json"
+        "path": "hub/other_tests/bulk_transfers/bulk-duplicated-transfers.json"
       },
       "requests": [
         {
@@ -634,9 +634,9 @@
               },
               {
                 "id": 3,
-                "description": "payerfsp callback - fspiop-source should be payeefsp",
+                "description": "payerfsp callback - fspiop-source should be switch",
                 "exec": [
-                  "expect(callback.headers['fspiop-source']).to.equal(environment.toFspId)"
+                  "expect(callback.headers['fspiop-source']).to.equal('switch')"
                 ]
               },
               {
@@ -778,9 +778,9 @@
               },
               {
                 "id": 23,
-                "description": "payeefsp request - fspiop-source should be testingtoolkitdfsp",
+                "description": "payeefsp request - fspiop-source should be switch",
                 "exec": [
-                  "expect(environment.bulkTransfersNegativeRequest.headers['fspiop-source']).to.equal(environment.fromFspId)"
+                  "expect(environment.bulkTransfersNegativeRequest.headers['fspiop-source']).to.equal('switch')"
                 ]
               },
               {

--- a/collections/hub/other_tests/bulk_transfers/fspiop_protocol_validation.json
+++ b/collections/hub/other_tests/bulk_transfers/fspiop_protocol_validation.json
@@ -90,9 +90,9 @@
               },
               {
                 "id": 3,
-                "description": "payerfsp callback - fspiop-source should be payeefsp",
+                "description": "payerfsp callback - fspiop-source should be switch",
                 "exec": [
-                  "expect(callback.headers['fspiop-source']).to.equal(environment.toFspId)"
+                  "expect(callback.headers['fspiop-source']).to.equal('switch')"
                 ]
               },
               {
@@ -234,9 +234,9 @@
               },
               {
                 "id": 23,
-                "description": "payeefsp request - fspiop-source should be testingtoolkitdfsp",
+                "description": "payeefsp request - fspiop-source should be switch",
                 "exec": [
-                  "expect(environment.bulkTransfersNegativeRequest.headers['fspiop-source']).to.equal(environment.fromFspId)"
+                  "expect(environment.bulkTransfersNegativeRequest.headers['fspiop-source']).to.equal('switch')"
                 ]
               },
               {

--- a/collections/hub/other_tests/bulk_transfers/negative_scenarios.json
+++ b/collections/hub/other_tests/bulk_transfers/negative_scenarios.json
@@ -556,9 +556,9 @@
               },
               {
                 "id": 3,
-                "description": "payer callback fspiop-source should be payeefsp",
+                "description": "payer callback fspiop-source should be switch",
                 "exec": [
-                  "expect(callback.headers['fspiop-source']).to.equal(environment.toFspId)"
+                  "expect(callback.headers['fspiop-source']).to.equal('switch')"
                 ]
               },
               {
@@ -700,9 +700,9 @@
               },
               {
                 "id": 23,
-                "description": "request to payee - fspiop-source should be testingtoolkitdfsp",
+                "description": "request to payee - fspiop-source should be switch",
                 "exec": [
-                  "expect(environment.bulkTransfersNegativeRequest.headers['fspiop-source']).to.equal(environment.fromFspId)"
+                  "expect(environment.bulkTransfersNegativeRequest.headers['fspiop-source']).to.equal('switch')"
                 ]
               },
               {

--- a/collections/hub/other_tests/bulk_transfers/positive_scenarios.json
+++ b/collections/hub/other_tests/bulk_transfers/positive_scenarios.json
@@ -90,9 +90,9 @@
               },
               {
                 "id": 3,
-                "description": "payerfsp callback - fspiop-source should be payeefsp",
+                "description": "payerfsp callback - fspiop-source should be switch",
                 "exec": [
-                  "expect(callback.headers['fspiop-source']).to.equal(environment.toFspId)"
+                  "expect(callback.headers['fspiop-source']).to.equal('switch')"
                 ]
               },
               {
@@ -234,9 +234,9 @@
               },
               {
                 "id": 23,
-                "description": "payeefsp request - fspiop-source should be testingtoolkitdfsp",
+                "description": "payeefsp request - fspiop-source should be switch",
                 "exec": [
-                  "expect(environment.bulkTransfersNegativeRequest.headers['fspiop-source']).to.equal(environment.fromFspId)"
+                  "expect(environment.bulkTransfersNegativeRequest.headers['fspiop-source']).to.equal('switch')"
                 ]
               },
               {
@@ -513,6 +513,7 @@
           },
           "ignoreCallbacks": true,
           "scriptingEngine": "javascript",
+          "disabled": false,
           "scripts": {
             "postRequest": {
               "exec": [
@@ -641,6 +642,7 @@
             ]
           },
           "ignoreCallbacks": false,
+          "disabled": false,
           "scripts": {
             "postRequest": {
               "exec": [


### PR DESCRIPTION
fix(mojaloop/#3024): [core bulk] POST /bulkTransfers from Switch to PayeeFSP to use Switch as fspiop-source - https://github.com/mojaloop/project/issues/3024
- updated other/bulk_transfers to correctly reflect "DESTINATION" headers to switch