### PR TITLE
feat(mojaloop/#3078): get /transfers callback is wrong for transf

### DIFF
--- a/collections/hub/golden_path/feature_tests/transfer_negative_scenarios/fulfil-reserved-v1.0.json
+++ b/collections/hub/golden_path/feature_tests/transfer_negative_scenarios/fulfil-reserved-v1.0.json
@@ -7,6 +7,9 @@
       "meta": {
         "info": "Fulfil Reserved 1.0"
       },
+      "fileInfo": {
+        "path": "golden_path/feature_tests/transfer_negative_scenarios/fulfil-reserved-v1.0.json"
+      },
       "requests": [
         {
           "id": 1,
@@ -69,34 +72,6 @@
             "note": "{$inputs.note}"
           },
           "scriptingEngine": "javascript",
-          "scripts": {
-            "preRequest": {
-              "exec": [
-                "if(environment.ENABLE_JWS_SIGNING) {",
-                "  custom.jws.signRequest(environment.TTKFSP_JWS_KEY)",
-                "}",
-                "",
-                "if (environment.ENABLE_WS_ASSERTIONS===true) {",
-                "  await websocket.connect(environment.PAYEEFSP_SDK_TESTAPI_WS_URL + '/requests/{$request.body.quoteId}', 'payeeRequest')",
-                "}"
-              ]
-            },
-            "postRequest": {
-              "exec": [
-                "if(environment.ENABLE_JWS_VALIDATION) {",
-                "  requestVariables.jwsValidationStatus =  custom.jws.validateCallback(callback.headers, callback.body, environment.SIMPAYEE_JWS_PUB_KEY)",
-                "}",
-                "else if(environment.ENABLE_PROTECTED_HEADERS_VALIDATION) {",
-                "  requestVariables.protectedHeadersValidationStatus =  custom.jws.validateCallbackProtectedHeaders(callback.headers)",
-                "}",
-                "",
-                "if (environment.ENABLE_WS_ASSERTIONS===true) {",
-                "  requestVariables.payeeRequest = await websocket.getMessage('payeeRequest', environment.WS_ASSERTION_TIMEOUT)",
-                "}",
-                ""
-              ]
-            }
-          },
           "tests": {
             "assertions": [
               {
@@ -268,7 +243,35 @@
               }
             ]
           },
-          "ignoreCallbacks": false
+          "ignoreCallbacks": false,
+          "scripts": {
+            "preRequest": {
+              "exec": [
+                "if(environment.ENABLE_JWS_SIGNING) {",
+                "  custom.jws.signRequest(environment.TTKFSP_JWS_KEY)",
+                "}",
+                "",
+                "if (environment.ENABLE_WS_ASSERTIONS===true) {",
+                "  await websocket.connect(environment.PAYEEFSP_SDK_TESTAPI_WS_URL + '/requests/{$request.body.quoteId}', 'payeeRequest')",
+                "}"
+              ]
+            },
+            "postRequest": {
+              "exec": [
+                "if(environment.ENABLE_JWS_VALIDATION) {",
+                "  requestVariables.jwsValidationStatus =  custom.jws.validateCallback(callback.headers, callback.body, environment.SIMPAYEE_JWS_PUB_KEY)",
+                "}",
+                "else if(environment.ENABLE_PROTECTED_HEADERS_VALIDATION) {",
+                "  requestVariables.protectedHeadersValidationStatus =  custom.jws.validateCallbackProtectedHeaders(callback.headers)",
+                "}",
+                "",
+                "if (environment.ENABLE_WS_ASSERTIONS===true) {",
+                "  requestVariables.payeeRequest = await websocket.getMessage('payeeRequest', environment.WS_ASSERTION_TIMEOUT)",
+                "}",
+                ""
+              ]
+            }
+          }
         },
         {
           "id": 2,
@@ -307,16 +310,6 @@
             "expiration": "{$requestVariables.transferExpiration}"
           },
           "ignoreCallbacks": true,
-          "scripts": {
-            "preRequest": {
-              "exec": [
-                "const additionalTimeoutExpiration = Number.parseFloat(environment.ADDITIONAL_TIMEOUT_EXPIRATION_MS) || 2000;",
-                "",
-                "requestVariables.transferExpiration = new Date(new Date().getTime() + additionalTimeoutExpiration).toISOString()",
-                ""
-              ]
-            }
-          },
           "scriptingEngine": "javascript",
           "tests": {
             "assertions": [
@@ -328,6 +321,16 @@
                 ]
               }
             ]
+          },
+          "scripts": {
+            "preRequest": {
+              "exec": [
+                "const additionalTimeoutExpiration = Number.parseFloat(environment.ADDITIONAL_TIMEOUT_EXPIRATION_MS) || 2000;",
+                "",
+                "requestVariables.transferExpiration = new Date(new Date().getTime() + additionalTimeoutExpiration).toISOString()",
+                ""
+              ]
+            }
           }
         },
         {
@@ -362,13 +365,6 @@
           },
           "ignoreCallbacks": true,
           "scriptingEngine": "javascript",
-          "scripts": {
-            "postRequest": {
-              "exec": [
-                "console.log(collectionVariables)"
-              ]
-            }
-          },
           "tests": {
             "assertions": [
               {
@@ -380,7 +376,14 @@
               }
             ]
           },
-          "delay": "500"
+          "delay": "500",
+          "scripts": {
+            "postRequest": {
+              "exec": [
+                "console.log(collectionVariables)"
+              ]
+            }
+          }
         },
         {
           "id": 4,
@@ -407,14 +410,6 @@
             "FSPIOP-Source": "{$inputs.fromFspId}",
             "Authorization": "{$inputs.TTK_BEARER_TOKEN}",
             "Content-Type": "{$inputs.contentTypeTransfers}"
-          },
-          "scripts": {
-            "preRequest": {
-              "exec": [
-                "// environment.newDateString = new Date(new Date().getTime() + 16000).toUTCString()",
-                "// console.log(environment.newDateString)"
-              ]
-            }
           },
           "scriptingEngine": "javascript",
           "tests": {
@@ -499,7 +494,15 @@
               }
             ]
           },
-          "delay": "500"
+          "delay": "500",
+          "scripts": {
+            "preRequest": {
+              "exec": [
+                "// environment.newDateString = new Date(new Date().getTime() + 16000).toUTCString()",
+                "// console.log(environment.newDateString)"
+              ]
+            }
+          }
         },
         {
           "id": 5,
@@ -526,13 +529,6 @@
             "FSPIOP-Source": "{$inputs.fromFspId}",
             "Authorization": "{$inputs.TTK_BEARER_TOKEN}",
             "Content-Type": "{$inputs.contentTypeTransfers}"
-          },
-          "scripts": {
-            "preRequest": {
-              "exec": [
-                ""
-              ]
-            }
           },
           "scriptingEngine": "javascript",
           "delay": "16000",
@@ -594,9 +590,9 @@
               },
               {
                 "id": 17,
-                "description": "Callback Header - fspiop-uri is /transfers/transferId/error",
+                "description": "Callback Header - fspiop-uri is /transfers/transferId",
                 "exec": [
-                  "expect(callback.headers['fspiop-uri']).to.equal('/transfers/' + request.params.ID+'/error')",
+                  "expect(callback.headers['fspiop-uri']).to.equal('/transfers/' + request.params.ID)",
                   ""
                 ]
               },
@@ -609,22 +605,38 @@
                 ]
               },
               {
-                "id": 19,
-                "description": "Callback Body -  errorCode is 3303",
+                "id": 21,
+                "description": "Callback Body - transferState is ABORTED",
                 "exec": [
-                  "expect(callback.body.errorInformation.errorCode).to.equal('3303')",
+                  "expect(callback.body.transferState).to.equal('ABORTED')",
                   ""
                 ]
               },
               {
-                "id": 20,
-                "description": "Callback Body -  errorDescription is Transfer expired",
+                "id": 22,
+                "description": "Callback Body - error cause in extensionList",
                 "exec": [
-                  "expect(callback.body.errorInformation.errorDescription).to.equal('Transfer expired')",
+                  "",
+                  "expect(callback.body).to.have.property('extensionList')",
+                  "expect(callback.body.extensionList).to.have.property('extension')",
+                  "",
+                  "const filteredExtensionListForCause = callback.body.extensionList.extension.filter(ext => ext.key === \"cause\")",
+                  "",
+                  "expect(filteredExtensionListForCause.length).to.equal(1)",
+                  "",
+                  "expect(filteredExtensionListForCause[0].value).to.equal(\"3303: Transfer expired\")",
+                  "",
                   ""
                 ]
               }
             ]
+          },
+          "scripts": {
+            "preRequest": {
+              "exec": [
+                ""
+              ]
+            }
           }
         }
       ]

--- a/collections/hub/golden_path/feature_tests/transfer_negative_scenarios/payee_invalid_timestamp.json
+++ b/collections/hub/golden_path/feature_tests/transfer_negative_scenarios/payee_invalid_timestamp.json
@@ -7,6 +7,9 @@
       "meta": {
         "info": "payee_invalid_timestamp"
       },
+      "fileInfo": {
+        "path": "golden_path/feature_tests/transfer_negative_scenarios/payee_invalid_timestamp.json"
+      },
       "requests": [
         {
           "id": 1,
@@ -581,7 +584,7 @@
                 "id": 17,
                 "description": "Callback Header - fspiop-uri is /transfers/transferId",
                 "exec": [
-                  "expect(callback.headers['fspiop-uri']).to.equal('/transfers/' + request.params.ID + '/error')",
+                  "expect(callback.headers['fspiop-uri']).to.equal('/transfers/' + request.params.ID)",
                   ""
                 ]
               },
@@ -595,18 +598,16 @@
               },
               {
                 "id": 19,
-                "description": "Callback Body -  errorCode is 3303",
+                "description": "Callback Body - error cause in extensionList",
                 "exec": [
-                  "expect(callback.body.errorInformation.errorCode).to.equal('3303')",
-                  ""
-                ]
-              },
-              {
-                "id": 20,
-                "description": "Callback Body -  errorDesciption is Transfer expired",
-                "exec": [
-                  "expect(callback.body.errorInformation.errorDescription).to.equal('Transfer expired')",
-                  ""
+                  "expect(callback.body).to.have.property('extensionList')",
+                  "expect(callback.body.extensionList).to.have.property('extension')",
+                  "",
+                  "const filteredExtensionListForCause = callback.body.extensionList.extension.filter(ext => ext.key === \"cause\")",
+                  "",
+                  "expect(filteredExtensionListForCause.length).to.equal(1)",
+                  "",
+                  "expect(filteredExtensionListForCause[0].value).to.equal(\"3303: Transfer expired\")"
                 ]
               }
             ]


### PR DESCRIPTION
feat(mojaloop/#3078): get /transfers callback is wrong for expired transfers - https://github.com/mojaloop/project/issues/3078
- updated transfer negative scenarios in the GP test collection to conform to FSPIOP Spec and code changes to the Central-Ledger