### PR TITLE
fix(mojaloop/3329): fixed accept and content type header in quotes requests in dfsp collection

### DIFF
--- a/collections/dfsp/golden_path/negative_scenarios/quotes_negative.json
+++ b/collections/dfsp/golden_path/negative_scenarios/quotes_negative.json
@@ -23,8 +23,8 @@
           "operationPath": "/quotes",
           "method": "post",
           "headers": {
-            "Accept": "{$inputs.accept}",
-            "Content-Type": "{$inputs.contentType}",
+            "Accept": "{$inputs.acceptQuotes}",
+            "Content-Type": "{$inputs.contentTypeQuotes}",
             "Date": "{$function.generic.curDate}",
             "FSPIOP-Source": "{$inputs.fromFspId}"
           },
@@ -167,7 +167,7 @@
           "operationPath": "/quotes",
           "method": "post",
           "headers": {
-            "Accept": "{$inputs.accept}",
+            "Accept": "{$inputs.acceptQuotes}",
             "Date": "{$function.generic.curDate}",
             "FSPIOP-Source": "{$inputs.fromFspId}"
           },
@@ -276,7 +276,7 @@
           "headers": {
             "Date": "{$function.generic.curDate}",
             "FSPIOP-Source": "{$inputs.fromFspId}",
-            "Content-Type": "{$inputs.contentType}"
+            "Content-Type": "{$inputs.contentTypeQuotes}"
           },
           "body": {
             "quoteId": "{$function.generic.generateUUID}",
@@ -381,9 +381,9 @@
           "operationPath": "/quotes",
           "method": "post",
           "headers": {
-            "Accept": "{$inputs.accept}",
+            "Accept": "{$inputs.acceptQuotes}",
             "FSPIOP-Source": "{$inputs.fromFspId}",
-            "Content-Type": "{$inputs.contentType}"
+            "Content-Type": "{$inputs.contentTypeQuotes}"
           },
           "body": {
             "quoteId": "{$function.generic.generateUUID}",
@@ -488,9 +488,9 @@
           "operationPath": "/quotes",
           "method": "post",
           "headers": {
-            "Accept": "{$inputs.accept}",
+            "Accept": "{$inputs.acceptQuotes}",
             "Date": "{$function.generic.curDate}",
-            "Content-Type": "{$inputs.contentType}"
+            "Content-Type": "{$inputs.contentTypeQuotes}"
           },
           "body": {
             "quoteId": "{$function.generic.generateUUID}",
@@ -963,9 +963,9 @@
           "operationPath": "/quotes",
           "method": "post",
           "headers": {
-            "Accept": "{$inputs.accept}",
+            "Accept": "{$inputs.acceptQuotes}",
             "FSPIOP-Source": "{$inputs.fromFspId}",
-            "Content-Type": "{$inputs.contentType}",
+            "Content-Type": "{$inputs.contentTypeQuotes}",
             "Date": "Th12312412"
           },
           "body": {


### PR DESCRIPTION
fix([mojaloop/3329](https://github.com/mojaloop/project/issues/3329)): fixed accept and content type header in quotes requests in dfsp collection