### PR TITLE
fix(mojaloop/#3927): add handler env var and target handler for health

### DIFF
--- a/collections/hub/golden_path/quoting_service/quoting_service.json
+++ b/collections/hub/golden_path/quoting_service/quoting_service.json
@@ -226,7 +226,7 @@
           "operationPath": "/health",
           "path": "/health",
           "method": "get",
-          "url": "{$inputs.HOST_QUOTING_SERVICE}",
+          "url": "{$inputs.HOST_QUOTING_SERVICE_HANDLER}",
           "tests": {
             "assertions": [
               {

--- a/environments/hub.json
+++ b/environments/hub.json
@@ -11,6 +11,7 @@
     "HOST_LEGACY_SIMULATOR": "http://simulator",
     "HOST_ML_API_ADAPTER": "http://ml-api-adapter-service",
     "HOST_QUOTING_SERVICE": "http://quoting-service",
+    "HOST_QUOTING_SERVICE_HANDLER": "http://quoting-service-handler",
     "HOST_SIMULATOR": "http://simulator",
     "HOST_TRANSACTION_REQUESTS_SERVICE": "http://transaction-requests-service",
     "HOST_THIRDPARTY_API_SVC": "http://thirdparty-api-svc",

--- a/environments/hub_cgs.json
+++ b/environments/hub_cgs.json
@@ -15,6 +15,7 @@
     "HOST_LEGACY_SIMULATOR": "http://$release_name-simulator",
     "HOST_ML_API_ADAPTER": "http://$release_name-ml-api-adapter-service",
     "HOST_QUOTING_SERVICE": "http://$release_name-quoting-service",
+    "HOST_QUOTING_SERVICE_HANDLER": "http://$release_name-quoting-service-handler",
     "HOST_SIMULATOR": "http://$release_name-simulator",
     "HOST_TRANSACTION_REQUESTS_SERVICE": "http://$release_name-transaction-requests-service",
     "HUB_OPERATOR_BEARER_TOKEN": "NOT_APPLICABLE",


### PR DESCRIPTION
The quoting service api handler no longer has the health status for the datastore.
When running in persistant mode the test will fail.
Updated the test with the quoting service handler which now contains the status instead.