### PR TITLE
fix: fixed  wrong assertions

### DIFF
--- a/collections/hub/golden_path/bug fixes/Tests for Bugfix #990 and #1016 - Quotes.json
+++ b/collections/hub/golden_path/bug fixes/Tests for Bugfix #990 and #1016 - Quotes.json
@@ -246,7 +246,7 @@
                 "exec": [
                   "if (!environment.SIMPLE_ROUTING_MODE_ENABLED) {",
                   "  if(environment.API_TYPE === 'fspiop') {",
-                  "    expect(typeof callback.body.errorInformation.errorDescription).to.include('Modified request');",
+                  "    expect(callback.body.errorInformation.errorDescription).to.include('Modified request');",
                   "  } else {",
                   "    expect(callback.body.errorInformation.errorDescription).to.not.equal(undefined);",
                   "  }",
@@ -359,7 +359,7 @@
                 "exec": [
                   "if (!environment.SIMPLE_ROUTING_MODE_ENABLED) {",
                   "  if(environment.API_TYPE === 'fspiop') {",
-                  "    expect(typeof callback.body.errorInformation.errorDescription).to.include('Modified request');",
+                  "    expect(callback.body.errorInformation.errorDescription).to.include('Modified request');",
                   "  } else {",
                   "    expect(callback.body.errorInformation.errorDescription).to.not.equal(undefined);",
                   "  }",


### PR DESCRIPTION
fixed  below wrong assertions (removed `typeof`)
```
if (!environment.SIMPLE_ROUTING_MODE_ENABLED) {
  if(environment.API_TYPE === 'fspiop') {
    expect(typeof callback.body.errorInformation.errorDescription).to.include('Modified request');
  } else {
    expect(callback.body.errorInformation.errorDescription).to.not.equal(undefined);
  }
}
```
to
```
if (!environment.SIMPLE_ROUTING_MODE_ENABLED) {
  if(environment.API_TYPE === 'fspiop') {
    expect(callback.body.errorInformation.errorDescription).to.include('Modified request');
  } else {
    expect(callback.body.errorInformation.errorDescription).to.not.equal(undefined);
  }
}
```