### PR TITLE
chore: add baggage header for skipping cache

### DIFF
--- a/collections/hub/golden_path/feature_tests/Active_Inactive_participants/active_and_inactive_participant.json
+++ b/collections/hub/golden_path/feature_tests/Active_Inactive_participants/active_and_inactive_participant.json
@@ -106,7 +106,6 @@
             },
             "note": "{$inputs.note}"
           },
-          "delay": "{$inputs.DELAY_QUOTES}",
           "ignoreCallbacks": true,
           "scriptingEngine": "javascript",
           "scripts": {
@@ -536,7 +535,6 @@
           },
           "ignoreCallbacks": true,
           "scriptingEngine": "javascript",
-          "delay": "{$inputs.DELAY_QUOTES}",
           "scripts": {
             "preRequest": {
               "exec": [

--- a/collections/hub/golden_path/feature_tests/Active_Inactive_participants/active_and_inactive_participant.json
+++ b/collections/hub/golden_path/feature_tests/Active_Inactive_participants/active_and_inactive_participant.json
@@ -67,7 +67,8 @@
             "Date": "{$function.generic.curDate}",
             "FSPIOP-Source": "{$inputs.SIM1_NAME}",
             "FSPIOP-Destination": "{$inputs.SIM2_NAME}",
-            "Authorization": "{$inputs.TESTFSP1_BEARER_TOKEN}"
+            "Authorization": "{$inputs.TESTFSP1_BEARER_TOKEN}",
+            "baggage": "{$inputs.skipParticipantCacheHeader}"
           },
           "body": {
             "quoteId": "{$function.generic.generateID}",
@@ -494,7 +495,8 @@
             "Date": "{$function.generic.curDate}",
             "FSPIOP-Source": "{$inputs.SIM1_NAME}",
             "Authorization": "{$inputs.TESTFSP1_BEARER_TOKEN}",
-            "FSPIOP-Destination": "{$inputs.SIM2_NAME}"
+            "FSPIOP-Destination": "{$inputs.SIM2_NAME}",
+            "baggage": "{$inputs.skipParticipantCacheHeader}"
           },
           "body": {
             "quoteId": "{$function.generic.generateID}",

--- a/collections/hub/golden_path/feature_tests/Active_Inactive_participants/active_and_inactive_participants_accounts.json
+++ b/collections/hub/golden_path/feature_tests/Active_Inactive_participants/active_and_inactive_participants_accounts.json
@@ -104,7 +104,8 @@
             "Date": "{$function.generic.curDate}",
             "FSPIOP-Source": "{$inputs.SIM1_NAME}",
             "Authorization": "{$inputs.TESTFSP1_BEARER_TOKEN}",
-            "FSPIOP-Destination": "{$inputs.SIM2_NAME}"
+            "FSPIOP-Destination": "{$inputs.SIM2_NAME}",
+            "baggage": "{$inputs.skipParticipantCacheHeader}"
           },
           "body": {
             "quoteId": "{$function.generic.generateID}",
@@ -531,7 +532,8 @@
             "Date": "{$function.generic.curDate}",
             "FSPIOP-Source": "{$inputs.SIM1_NAME}",
             "Authorization": "{$inputs.TESTFSP1_BEARER_TOKEN}",
-            "FSPIOP-Destination": "{$inputs.SIM2_NAME}"
+            "FSPIOP-Destination": "{$inputs.SIM2_NAME}",
+            "baggage": "{$inputs.skipParticipantCacheHeader}"
           },
           "body": {
             "quoteId": "{$function.generic.generateID}",

--- a/collections/hub/golden_path/feature_tests/Active_Inactive_participants/active_and_inactive_participants_accounts.json
+++ b/collections/hub/golden_path/feature_tests/Active_Inactive_participants/active_and_inactive_participants_accounts.json
@@ -143,7 +143,6 @@
             },
             "note": "{$inputs.note}"
           },
-          "delay": "{$inputs.DELAY_QUOTES}",
           "ignoreCallbacks": true,
           "scriptingEngine": "javascript",
           "scripts": {
@@ -571,7 +570,6 @@
             },
             "note": "{$inputs.note}"
           },
-          "delay": "{$inputs.DELAY_QUOTES}",
           "ignoreCallbacks": true,
           "scriptingEngine": "javascript",
           "scripts": {

--- a/collections/hub/golden_path/feature_tests/block_transfer.json
+++ b/collections/hub/golden_path/feature_tests/block_transfer.json
@@ -153,7 +153,8 @@
             "FSPIOP-Destination": "{$inputs.SIMPAYEE_NAME}",
             "FSPIOP-HTTP-Method": "POST",
             "FSPIOP-URI": "/quotes",
-            "Date": "{$function.generic.curDate}"
+            "Date": "{$function.generic.curDate}",
+            "baggage": "{$inputs.skipParticipantCacheHeader}"
           },
           "body": {
             "quoteId": "{$requestVariables.quoteId}",
@@ -964,7 +965,8 @@
             "FSPIOP-Destination": "{$inputs.SIMPAYEE_NAME}",
             "FSPIOP-HTTP-Method": "POST",
             "FSPIOP-URI": "/quotes",
-            "Date": "{$function.generic.curDate}"
+            "Date": "{$function.generic.curDate}",
+            "baggage": "{$inputs.skipParticipantCacheHeader}"
           },
           "body": {
             "quoteId": "{$requestVariables.quoteId}",

--- a/collections/hub/golden_path/feature_tests/block_transfer.json
+++ b/collections/hub/golden_path/feature_tests/block_transfer.json
@@ -153,8 +153,7 @@
             "FSPIOP-Destination": "{$inputs.SIMPAYEE_NAME}",
             "FSPIOP-HTTP-Method": "POST",
             "FSPIOP-URI": "/quotes",
-            "Date": "{$function.generic.curDate}",
-            "baggage": "{$inputs.skipParticipantCacheHeader}"
+            "Date": "{$function.generic.curDate}"
           },
           "body": {
             "quoteId": "{$requestVariables.quoteId}",
@@ -965,8 +964,7 @@
             "FSPIOP-Destination": "{$inputs.SIMPAYEE_NAME}",
             "FSPIOP-HTTP-Method": "POST",
             "FSPIOP-URI": "/quotes",
-            "Date": "{$function.generic.curDate}",
-            "baggage": "{$inputs.skipParticipantCacheHeader}"
+            "Date": "{$function.generic.curDate}"
           },
           "body": {
             "quoteId": "{$requestVariables.quoteId}",

--- a/environments/hub.json
+++ b/environments/hub.json
@@ -219,6 +219,7 @@
     "TTKSIM2_PARTY_TIMES_OUT": "partytimesout",
     "ttkpayeefspIdentifier1": "5671234",
     "ttkpayeefspIdentifier2": "5201",
-    "ttkpayeefspName": "ttkpayeefsp"
+    "ttkpayeefspName": "ttkpayeefsp",
+    "skipParticipantCacheHeader": "test-instruction=skip-participant-cache"
   }
 }


### PR DESCRIPTION
This pull request adds support for a new custom header, `baggage`, to several API test scenarios. The header is dynamically set using the `skipParticipantCacheHeader` environment variable, which is also introduced in the environment configuration. This allows tests to instruct the system to skip participant cache as part of the request flow.

**Test scenario updates:**

* Added the `baggage` header (with value from `skipParticipantCacheHeader`) to requests in `active_and_inactive_participant.json` and `active_and_inactive_participants_accounts.json` to enable cache-skipping in participant-related flows. [[1]](diffhunk://#diff-5f15e5c659ae9eae7c1e376c922200616ebcccd0d71f398e93d6aa57b0010f7aL70-R71) [[2]](diffhunk://#diff-5f15e5c659ae9eae7c1e376c922200616ebcccd0d71f398e93d6aa57b0010f7aL497-R499) [[3]](diffhunk://#diff-a2a85dfc5cd59d552024f444fd908af004244438f60f58cbe5a6de3878a1e11aL107-R108) [[4]](diffhunk://#diff-a2a85dfc5cd59d552024f444fd908af004244438f60f58cbe5a6de3878a1e11aL534-R536)
* Added the `baggage` header to relevant requests in `block_transfer.json` to ensure cache-skipping is also tested in block transfer scenarios. [[1]](diffhunk://#diff-8f8ee00c8379d0f4eba276bbb109d9f369ef4a258d3a51e5b53d2a9025d91061L156-R157) [[2]](diffhunk://#diff-8f8ee00c8379d0f4eba276bbb109d9f369ef4a258d3a51e5b53d2a9025d91061L967-R969)

**Environment configuration:**

* Introduced the `skipParticipantCacheHeader` variable in `hub.json` with the value `test-instruction=skip-participant-cache`, making it available for use in the updated test scenarios.