### PR TITLE
feat: add TTK tests for bug fix #4198    
  (quoting-service proper HTTP error handling)

### DIFF
--- a/collections/hub/golden_path/bug fixes/Test for Bugfix #4198 - Proper HTTP error handling in quoting-service.json
+++ b/collections/hub/golden_path/bug fixes/Test for Bugfix #4198 - Proper HTTP error handling in quoting-service.json
@@ -1,0 +1,205 @@
+{
+  "name": "multi",
+  "test_cases": [
+    {
+      "id": "bugfix-4198",
+      "name": "Tests for Bugfix #4198 - Proper HTTP error handling in quoting-service (no blanket 1001 wrapping)",
+      "meta": {
+        "info": "Tests for Bugfix mojaloop/project#4198 - quoting-service and its callers were wrapping ALL axios errors (including HTTP 4xx with FSPIOP errorInformation) as DESTINATION_COMMUNICATION_ERROR (errorCode 1001 -> HTTP 503), masking the real downstream failure.\n\nThe fix in mojaloop/quoting-service#468 (src/lib/http.js, src/model/quotes.js, src/model/fxQuotes.js, src/model/bulkQuotes.js) now distinguishes:\n  - Response with FSPIOP errorInformation -> original errorCode is propagated directly\n  - HTTP 4xx without errorInformation    -> CLIENT_ERROR (errorCode 3000)\n  - HTTP 5xx / network failure           -> DESTINATION_COMMUNICATION_ERROR (errorCode 1001) -- unchanged\n\nThese tests assert the regression-guard invariant: a 4xx from a downstream hop (participant endpoint lookup in central-ledger for a non-existent destination FSP) must NO LONGER surface to the caller as errorCode 1001. The specific replacement code depends on whether central-ledger returns FSPIOP errorInformation (then that original code is preserved, typically 3201 DESTINATION_FSP_ERROR or 3003) or a plain 4xx (then 3000 CLIENT_ERROR).\n\nDepends on: mojaloop/quoting-service#468"
+      },
+      "requests": [
+        {
+          "id": "quote-nonexistent-destination",
+          "meta": {
+            "info": "POST /quotes with a FSPIOP-Destination that is not registered in the hub. The participant-endpoint lookup inside quoting-service returns a 4xx; pre-fix this became errorCode 1001 (HTTP 503) in the caller's callback. Post-fix the caller sees the real downstream error."
+          },
+          "description": "Regression guard: POST /quotes to non-existent destination FSP must not surface as 1001",
+          "apiVersion": {
+            "minorVersion": 1,
+            "majorVersion": 1,
+            "type": "fspiop",
+            "asynchronous": true
+          },
+          "operationPath": "/quotes",
+          "path": "/quotes",
+          "method": "post",
+          "url": "{$inputs.HOST_QUOTING_SERVICE}",
+          "headers": {
+            "Accept": "{$inputs.acceptQuotes}",
+            "Content-Type": "{$inputs.contentTypeQuotes}",
+            "Date": "{$function.generic.curDate}",
+            "FSPIOP-Source": "{$inputs.fromFspId}",
+            "FSPIOP-Destination": "nonexistentfsp4198"
+          },
+          "body": {
+            "quoteId": "{$function.generic.generateID}",
+            "transactionId": "{$function.generic.generateID}",
+            "payer": {
+              "partyIdInfo": {
+                "partyIdType": "{$inputs.fromIdType}",
+                "partyIdentifier": "{$inputs.fromIdValue}",
+                "fspId": "{$inputs.fromFspId}"
+              },
+              "personalInfo": {
+                "complexName": {
+                  "firstName": "{$inputs.fromFirstName}",
+                  "lastName": "{$inputs.fromLastName}"
+                },
+                "dateOfBirth": "{$inputs.fromDOB}"
+              }
+            },
+            "payee": {
+              "partyIdInfo": {
+                "partyIdType": "{$inputs.toIdType}",
+                "partyIdentifier": "{$inputs.toIdValue}",
+                "fspId": "nonexistentfsp4198"
+              }
+            },
+            "amountType": "SEND",
+            "amount": {
+              "amount": "{$inputs.amount}",
+              "currency": "{$inputs.currency}"
+            },
+            "transactionType": {
+              "scenario": "TRANSFER",
+              "initiator": "PAYER",
+              "initiatorType": "CONSUMER"
+            },
+            "note": "{$inputs.note}"
+          },
+          "tests": {
+            "assertions": [
+              {
+                "id": "rsp-status-202",
+                "description": "Initial sync response should be 202 Accepted (quoting-service accepts the request and will process it asynchronously)",
+                "exec": [
+                  "expect(response.status).to.equal(202)"
+                ]
+              },
+              {
+                "id": "cb-errorInformation",
+                "description": "Async PUT /quotes/{ID}/error callback body should contain errorInformation",
+                "exec": [
+                  "expect(callback.body).to.have.property('errorInformation')"
+                ]
+              },
+              {
+                "id": "cb-error-code-present",
+                "description": "Callback errorInformation should contain errorCode",
+                "exec": [
+                  "expect(callback.body.errorInformation).to.have.property('errorCode')"
+                ]
+              },
+              {
+                "id": "cb-error-code-not-1001",
+                "description": "Regression-guard: errorCode MUST NOT be 1001 (DESTINATION_COMMUNICATION_ERROR). Pre-fix this assertion fails because quoting-service blanket-wrapped all axios errors as 1001; post-fix the real downstream errorCode is propagated.",
+                "exec": [
+                  "expect(callback.body.errorInformation.errorCode).to.not.equal('1001')"
+                ]
+              },
+              {
+                "id": "cb-error-code-expected-family",
+                "description": "Expected post-fix errorCode is either 3xxx (FSPIOP errorInformation propagated from central-ledger, typically 3003 Party/3201 Destination FSP not found) or 3000 (CLIENT_ERROR for 4xx without errorInformation). Assertion is tolerant so it stays green across both paths.",
+                "exec": [
+                  "expect(callback.body.errorInformation.errorCode).to.match(/^3\\d{3}$/)"
+                ]
+              },
+              {
+                "id": "cb-fspiop-destination-echo",
+                "description": "Callback fspiop-destination should echo the original FSPIOP-Source (the caller receives their own error)",
+                "exec": [
+                  "expect(callback.headers['fspiop-destination']).to.equal('{$request.headers[\"FSPIOP-Source\"]}')"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "id": "quote-positive-control",
+          "meta": {
+            "info": "Positive control - POST /quotes to a valid destination must still succeed (regression guard against the fix accidentally breaking the happy path)."
+          },
+          "description": "Positive control: valid quote request to provisioned payee FSP still works end-to-end",
+          "apiVersion": {
+            "minorVersion": 1,
+            "majorVersion": 1,
+            "type": "fspiop",
+            "asynchronous": true
+          },
+          "operationPath": "/quotes",
+          "path": "/quotes",
+          "method": "post",
+          "url": "{$inputs.HOST_QUOTING_SERVICE}",
+          "headers": {
+            "Accept": "{$inputs.acceptQuotes}",
+            "Content-Type": "{$inputs.contentTypeQuotes}",
+            "Date": "{$function.generic.curDate}",
+            "FSPIOP-Source": "{$inputs.fromFspId}",
+            "FSPIOP-Destination": "{$inputs.toFspId}"
+          },
+          "body": {
+            "quoteId": "{$function.generic.generateID}",
+            "transactionId": "{$function.generic.generateID}",
+            "payer": {
+              "partyIdInfo": {
+                "partyIdType": "{$inputs.fromIdType}",
+                "partyIdentifier": "{$inputs.fromIdValue}",
+                "fspId": "{$inputs.fromFspId}"
+              },
+              "personalInfo": {
+                "complexName": {
+                  "firstName": "{$inputs.fromFirstName}",
+                  "lastName": "{$inputs.fromLastName}"
+                },
+                "dateOfBirth": "{$inputs.fromDOB}"
+              }
+            },
+            "payee": {
+              "partyIdInfo": {
+                "partyIdType": "{$inputs.toIdType}",
+                "partyIdentifier": "{$inputs.toIdValue}",
+                "fspId": "{$inputs.toFspId}"
+              }
+            },
+            "amountType": "SEND",
+            "amount": {
+              "amount": "{$inputs.amount}",
+              "currency": "{$inputs.currency}"
+            },
+            "transactionType": {
+              "scenario": "TRANSFER",
+              "initiator": "PAYER",
+              "initiatorType": "CONSUMER"
+            },
+            "note": "{$inputs.note}"
+          },
+          "tests": {
+            "assertions": [
+              {
+                "id": "rsp-status-202",
+                "description": "Initial sync response should be 202 Accepted",
+                "exec": [
+                  "expect(response.status).to.equal(202)"
+                ]
+              },
+              {
+                "id": "cb-no-errorInformation",
+                "description": "Callback body should NOT contain errorInformation on the happy path",
+                "exec": [
+                  "expect(callback.body).to.not.have.property('errorInformation')"
+                ]
+              },
+              {
+                "id": "cb-has-transferAmount",
+                "description": "Callback body should contain a valid quote response payload (transferAmount)",
+                "exec": [
+                  "expect(callback.body).to.have.property('transferAmount')"
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/collections/hub/golden_path/bug fixes/master.json
+++ b/collections/hub/golden_path/bug fixes/master.json
@@ -45,6 +45,14 @@
     {
       "name": "Test for 4 decimal points #949.json",
       "type": "file"
+    },
+    {
+      "name": "Test for Bugfix #4198 - Proper HTTP error handling in quoting-service.json",
+      "type": "file",
+      "labels": [
+        "quotes",
+        "quoting-service"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds a TTK test collection that guards the regression fixed by [mojaloop/quoting-service#468](https://github.com/mojaloop/quoting-service/pull/468) for [mojaloop/project#4198](https://github.com/mojaloop/project/issues/4198):

> quoting-service was wrapping ALL axios errors from downstream hops — including HTTP 4xx responses that carry a proper FSPIOP `errorInformation` payload — as `DESTINATION_COMMUNICATION_ERROR` (errorCode **1001** → HTTP 503). The real downstream error code was lost, making diagnosis harder and incorrectly telling the caller *"the system is unavailable"*.

The fix in #468 distinguishes three paths:

| Downstream response | Before fix | After fix |
|---|---|---|
| HTTP 4xx with FSPIOP `errorInformation` | 1001 `DESTINATION_COMMUNICATION_ERROR` | Propagated directly (e.g. 3003, 3201) |
| HTTP 4xx without `errorInformation` | 1001 | **3000** `CLIENT_ERROR` |
| HTTP 5xx / network error | 1001 | 1001 (unchanged) |

## Test scenarios

1. **`quote-nonexistent-destination`** — regression guard. `POST /quotes` with `FSPIOP-Destination: nonexistentfsp4198`. The participant-endpoint lookup inside quoting-service returns a 4xx from central-ledger.

   Assertions:
   - Sync response `202 Accepted`
   - Async callback body has `errorInformation`
   - **`errorCode` is NOT `1001`** ← the key regression-guard invariant
   - `errorCode` matches `/^3\d{3}$/` — tolerant of whichever fix branch runs (propagated 3xxx or `CLIENT_ERROR` 3000)
   - Callback `fspiop-destination` echoes the caller's `FSPIOP-Source`

2. **`quote-positive-control`** — happy path. `POST /quotes` to the provisioned `toFspId`. Asserts `202`, callback has a valid `transferAmount`, no `errorInformation`. Guards against the fix accidentally breaking the normal flow.

## Why tolerant on error code (3xxx)

The exact replacement for `1001` depends on whether the downstream hop returns a body with FSPIOP `errorInformation`:
- If central-ledger's participant-endpoint lookup responds with an FSPIOP error body, quoting-service now propagates that errorCode unchanged (typically `3201` DESTINATION_FSP_ERROR or `3003`).
- If it returns plain 4xx JSON (no `errorInformation`), quoting-service emits `3000` CLIENT_ERROR.

The regex `/^3\d{3}$/` accepts either branch. If the downstream protocol is changed in the future so that a *different* 3xxx code comes back, the test still passes; only a regression to `1001` (or `5xxx`) fails the build.

## Depends on

**mojaloop/quoting-service#468** — still OPEN at time of writing. Keeping this PR as **draft** until #468 merges. Flip to ready-for-review immediately afterward.

## Files

- **new**: `collections/hub/golden_path/bug fixes/Test for Bugfix #4198 - Proper HTTP error handling in quoting-service.json`
- **modified**: `collections/hub/golden_path/bug fixes/master.json` — registers the new file with labels `quotes` and `quoting-service`

## Verification

Once #468 is merged and an image is built from `mojaloop/quoting-service:main`:

```bash
cd /path/to/ml-core-test-harness
# point the harness .env at the new quoting-service image
# QUOTING_SERVICE_VERSION=<tag-built-from-main>

docker compose up -d quoting-service quoting-service-handler \
                     mojaloop-testing-toolkit mojaloop-testing-toolkit-ui

# copy this collection + master.json edit into the harness test-cases mount:
#   docker/ml-testing-toolkit/test-cases/collections/tests/golden_path/bug fixes/

docker run --rm --network mojaloop-net \
  -v "$(pwd)/docker/ml-testing-toolkit/test-cases/collections:/opt/app/collections" \
  -v "$(pwd)/docker/ml-testing-toolkit/test-cases/environments:/opt/app/environments" \
  mojaloop/ml-testing-toolkit-client-lib:v1.9.1 \
  npm run cli -- -u http://mojaloop-testing-toolkit:5050 \
    -i "collections/tests/golden_path/bug fixes/Test for Bugfix #4198 - Proper HTTP error handling in quoting-service.json" \
    -e environments/default-env.json
```

Expected (post-fix): all assertions pass, exit code 0.

Regression sanity check (pre-fix): point `QUOTING_SERVICE_VERSION` at an image built from `mojaloop/quoting-service:main` *before* #468. The first scenario's `cb-error-code-not-1001` assertion should fail because the caller receives `errorCode: 1001`.

## Scope note

The fix touches `fxQuotes.js` and `bulkQuotes.js` too. A future follow-up can add equivalent scenarios for `POST /fxQuotes` and `POST /bulkQuotes`, but the three models share the same code pattern, and the `src/lib/http.js` fix is exercised by any quote-style endpoint — so this single collection functions as a representative regression guard.

## Test plan

- [ ] Reviewer waits for mojaloop/quoting-service#468 to merge.
- [ ] Reviewer builds a quoting-service image from `mojaloop/quoting-service:main` post-merge.
- [ ] Reviewer runs the collection as above — both test cases pass.
- [ ] Reviewer (optionally) runs against a pre-#468 image to confirm the regression guard catches the original bug (`errorCode: 1001` in the callback → the `cb-error-code-not-1001` assertion goes red).
